### PR TITLE
Fix boolean handling in string.find

### DIFF
--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -1,7 +1,15 @@
 import { sprintf } from 'printj'
 import { Table } from '../Table'
 import { LuaError } from '../LuaError'
-import { tostring, posrelat, coerceArgToNumber, coerceArgToString, hasOwnProperty, LuaType } from '../utils'
+import {
+    tostring,
+    posrelat,
+    coerceArgToNumber,
+    coerceArgToString,
+    hasOwnProperty,
+    LuaType,
+    coerceToBoolean
+} from '../utils'
 
 const ROSETTA_STONE: Record<string, string> = {
     '([^a-zA-Z0-9%(])-': '$1*?',
@@ -117,7 +125,7 @@ function find(s: LuaType, pattern: LuaType, init: LuaType, plain: LuaType): (num
     const S = coerceArgToString(s, 'find', 1)
     const P = coerceArgToString(pattern, 'find', 2)
     const INIT = init === undefined ? 1 : coerceArgToNumber(init, 'find', 3)
-    const PLAIN = plain === undefined ? false : coerceArgToNumber(plain, 'find', 4)
+    const PLAIN = plain === undefined ? false : coerceToBoolean(plain)
 
     // Regex
     if (!PLAIN) {

--- a/tests/starlight/lib-string.lua
+++ b/tests/starlight/lib-string.lua
@@ -101,6 +101,13 @@ b = string.find(a, 'The .* fox')
 assertTrue (b == 1, 'The dot pattern should match across lines in string.find()')
 
 
+local ok, plainFind = pcall(function () return string.find('abc', 'a.c', 1, true) end)
+assertTrue (ok and plainFind == nil, 'string.find() should accept a boolean plain argument and disable pattern matching')
+
+local literalFind = string.find('a.c', 'a.c', 1, true)
+assertTrue (literalFind == 1, 'string.find() should find literal matches when plain is true')
+
+
 
 -- format
 


### PR DESCRIPTION
## Summary
- ensure `string.find` treats the fourth argument as a boolean flag instead of a number
- add tests covering `string.find` with the boolean plain parameter

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfd1f61b4832a843c624bdceb888f