### PR TITLE
Handle generator-based Lua function calls

### DIFF
--- a/src/Table.ts
+++ b/src/Table.ts
@@ -1,4 +1,4 @@
-import { hasOwnProperty, LuaType, tostring } from './utils'
+import { hasOwnProperty, LuaType, tostring, executeFunction } from './utils'
 
 type MetaMethods =
     // unary op
@@ -69,8 +69,7 @@ class Table {
             }
 
             if (typeof mm === 'function') {
-                const v = mm.call(undefined, this, key)
-                return v instanceof Array ? v[0] : v
+                return executeFunction(mm, this, key)[0]
             }
         }
 
@@ -108,7 +107,8 @@ class Table {
                     return mm.set(key, value)
                 }
                 if (typeof mm === 'function') {
-                    return mm(this, key, value)
+                    executeFunction(mm, this, key, value)
+                    return
                 }
             }
         }

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -8,7 +8,8 @@ import {
     hasOwnProperty,
     LuaType,
     posrelat,
-    tostring
+    tostring,
+    executeFunction
 } from '../utils'
 
 const ROSETTA_STONE: Record<string, string> = {
@@ -239,8 +240,8 @@ function gsub(s: LuaType, pattern: LuaType, repl: LuaType, n?: LuaType): string 
     const REPL = ((): ((strs: string[]) => string) => {
         if (typeof repl === 'function')
             return strs => {
-                const ret = repl(strs[0])[0]
-                return ret === undefined ? strs[0] : ret
+                const ret = executeFunction(repl, strs[0])[0]
+                return (ret === undefined ? strs[0] : ret) as string
             }
 
         if (repl instanceof Table) return strs => repl.get(strs[0]).toString()

--- a/src/lib/table.ts
+++ b/src/lib/table.ts
@@ -5,7 +5,8 @@ import {
     coerceArgToNumber,
     coerceArgToString,
     coerceArgToTable,
-    coerceArgToFunction
+    coerceArgToFunction,
+    executeFunction
 } from '../utils'
 import { LuaError } from '../LuaError'
 
@@ -147,7 +148,7 @@ function sort(table: Table, comp?: Function): void {
 
     if (comp) {
         const COMP = coerceArgToFunction(comp, 'sort', 2)
-        sortFunc = (a, b) => (coerceToBoolean(COMP(a, b)[0]) ? -1 : 1)
+        sortFunc = (a, b) => (coerceToBoolean(executeFunction(COMP, a, b)[0]) ? -1 : 1)
     } else {
         sortFunc = (a, b) => (a < b ? -1 : 1)
     }

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,5 +1,5 @@
 import { MetaMethods, Table } from './Table'
-import { coerceToNumber, coerceToString, LuaType, coerceToBoolean } from './utils'
+import { coerceToNumber, coerceToString, LuaType, coerceToBoolean, executeFunction } from './utils'
 import { LuaError } from './LuaError'
 
 const binaryArithmetic = <R extends boolean | number>(
@@ -11,7 +11,7 @@ const binaryArithmetic = <R extends boolean | number>(
     const mm =
         (left instanceof Table && left.getMetaMethod(metaMethodName)) ||
         (right instanceof Table && right.getMetaMethod(metaMethodName))
-    if (mm) return mm(left, right)[0]
+    if (mm) return executeFunction(mm, left, right)[0] as R
 
     const L = coerceToNumber(left, 'attempt to perform arithmetic on a %type value')
     const R = coerceToNumber(right, 'attempt to perform arithmetic on a %type value')
@@ -52,14 +52,14 @@ const not = (value: LuaType): boolean => !bool(value)
 
 const unm = (value: LuaType): number => {
     const mm = value instanceof Table && value.getMetaMethod('__unm')
-    if (mm) return mm(value)[0]
+    if (mm) return executeFunction(mm, value)[0] as number
 
     return -1 * coerceToNumber(value, 'attempt to perform arithmetic on a %type value')
 }
 
 const bnot = (value: LuaType): number => {
     const mm = value instanceof Table && value.getMetaMethod('__bnot')
-    if (mm) return mm(value)[0]
+    if (mm) return executeFunction(mm, value)[0] as number
 
     return ~coerceToNumber(value, 'attempt to perform arithmetic on a %type value')
 }
@@ -67,7 +67,7 @@ const bnot = (value: LuaType): number => {
 const len = (value: LuaType): number => {
     if (value instanceof Table) {
         const mm = value.getMetaMethod('__len')
-        if (mm) return mm(value)[0]
+        if (mm) return executeFunction(mm, value)[0] as number
 
         return value.getn()
     }
@@ -135,7 +135,7 @@ const concat = (left: LuaType, right: LuaType): string => {
     const mm =
         (left instanceof Table && left.getMetaMethod('__concat')) ||
         (right instanceof Table && right.getMetaMethod('__concat'))
-    if (mm) return mm(left, right)[0]
+    if (mm) return executeFunction(mm, left, right)[0] as string
 
     const L = coerceToString(left, 'attempt to concatenate a %type value')
     const R = coerceToString(right, 'attempt to concatenate a %type value')
@@ -152,7 +152,7 @@ const eq = (left: LuaType, right: LuaType): boolean => {
         left.metatable === right.metatable &&
         left.getMetaMethod('__eq')
 
-    if (mm) return !!mm(left, right)[0]
+    if (mm) return !!executeFunction(mm, left, right)[0]
 
     return left === right
 }


### PR DESCRIPTION
## Summary
- add `executeFunction` helper to run Lua functions and generators
- invoke metamethods and callbacks through `executeFunction`
- fix `pcall`/`xpcall`, string.gsub, and table.sort to execute Lua callbacks properly

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada6b002d4832a9ad8af7276778cdd